### PR TITLE
build(docker): Use LTS versions for Node and MongoDB.

### DIFF
--- a/docker-compose-isolated.yml
+++ b/docker-compose-isolated.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
     db:
-        image: mongo:3.2.6
+        image: mongo:3.6
         ports:
             - "27017:27017"
     open-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
     open-api:
-        image: node:8.9.0
+        image: node:8.10
         volumes:
             - .:/fcc-openapi
         working_dir: /fcc-openapi


### PR DESCRIPTION
Addresses #20 