### PR TITLE
chore: temporarily ignore hoek for 30 days

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,9 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.10.2
-ignore: {}
+version: v1.11.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:hoek:20180212':
+    - '*':
+        reason: 'Low sev, no fix available'
+        expires: 2018-05-20T02:45:20.389Z
 patch: {}


### PR DESCRIPTION
Addresses  #52 and is the result of running 
```sh
▶ snyk ignore --id='npm:hoek:20180212'  --reason='Low sev, no fix available'
```

