### PR TITLE
refactor(build): reinstate node_modules caching, use pre-installed yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "lts/*"
 cache:
   yarn: true
+  directories: "node_modules"
 
 env:
   global:
@@ -12,9 +13,8 @@ env:
     - SLS_DEBUG=true
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
-  - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add serverless
+  - export PATH=$(yarn global dir)/node_modules/.bin:$PATH
 
 script:
   - yarn lint

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,5 +29,4 @@ fi
 
 
 echo "Deploying from branch $BRANCH to stage $STAGE"
-yarn install --production --ignore-scripts --prefer-offline
 sls deploy --stage $STAGE --region $AWS_REGION


### PR DESCRIPTION
* Use Yarn provided by Travis - they will provide Yarn if a yarn.lock is found in the root of the repository
* Cache node_modules
* Add location where Yarn installs globally to PATH for deployment script to use
* Remove redundant `yarn install` step from deploy script