### PR TITLE
chore(tools): snyk should run only in production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write es5 './**/*.{js,json}' && yarn lint",
     "lint": "eslint ./**/*.js --fix",
     "prepare-production": "snyk protect",
-    "prepublish": "yarn snyk-protect",
+    "prepublishOnly": "yarn snyk-protect",
     "snyk-protect": "snyk protect",
     "snyk-test": "snyk test",
     "start":

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,4 +31,5 @@ fi
 
 
 echo "Deploying from branch $BRANCH to stage $STAGE"
+yarn prepare-production
 sls deploy --stage $STAGE --region $AWS_REGION


### PR DESCRIPTION
This removes snyk protect in development mode, which is fine as long as the scripts are automated to do this on deploy and package publishing, will make the CI faster and local installs less of annoyance

Closes #84