### PR TITLE
feat: increase verbosity of Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "snyk-test": "snyk test",
     "start":
       "cross-env DEBUG=fcc:* nodemon node_modules/serverless/bin/serverless offline start --skipCacheInvalidation",
-    "test": "cross-env JWT_CERT=test jest",
-    "test-ci": "cross-env JWT_CERT=test jest --runInBand"
+    "test": "cross-env JWT_CERT=test jest --verbose",
+    "test-ci": "cross-env JWT_CERT=test jest --runInBand --verbose"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
I like seeing which tests ran.

Currently:

```sh
▶ JWT_CERT=test jest
 PASS  test/integration/users.test.js
 PASS  graphql/resolvers/directive.test.js

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.603s, estimated 2s
Ran all test suites.
```

With `--verbose`:

```sh
▶ JWT_CERT=test jest --verbose
 PASS  test/integration/users.test.js
  ✓ should return null users and auth error without a token (45ms)
  ✓ should return null users and auth error with an invalid token (3ms)
  ✓ should return a user after one has been created (42ms)

 PASS  graphql/resolvers/directive.test.js
  isAuthenticatedOnField
    ✓ should return null if authenication fails (4ms)
    ✓ should return the secretValue if authentication succeeds
  isAuthenticatedOnQuery
    ✓ should throw an error is auth fails (1ms)
    ✓ should call next if auth succeeds

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.534s, estimated 2s
Ran all test suites.
```