### PR TITLE
feat(hardening): limits query depth

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -1,6 +1,7 @@
 import { graphqlLambda } from 'apollo-server-lambda';
 import lambdaPlayground from 'graphql-playground-middleware-lambda';
 import { makeExecutableSchema } from 'graphql-tools';
+import depthLimit from 'graphql-depth-limit';
 import debug from 'debug';
 
 import typeDefs from './graphql/typeDefs';
@@ -51,7 +52,8 @@ exports.graphqlHandler = async function graphqlHandler(
         functionName,
         event,
         context
-      }
+      },
+      validationRules: [depthLimit(10)]
     };
   });
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "bluebird": "^3.5.1",
     "dotenv": "^5.0.1",
     "graphql": "0.13.2",
+    "graphql-depth-limit": "^1.1.0",
     "graphql-playground-middleware-lambda": "^1.5.1",
     "graphql-tools": "^2.24.0",
     "jsonwebtoken": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,6 +3075,12 @@ graphql-config@2.0.0:
     lodash "^4.17.4"
     minimatch "^3.0.4"
 
+graphql-depth-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz#59fe6b2acea0ab30ee7344f4c75df39cc18244e8"
+  dependencies:
+    arrify "^1.0.1"
+
 graphql-extensions@^0.0.x, graphql-extensions@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.10.tgz#34bdb2546d43f6a5bc89ab23c295ec0466c6843d"


### PR DESCRIPTION
Addresses #25 This will limit the query depth to 10, see https://github.com/stems/graphql-depth-limit for more information.

Once we have types contain references to each other people could create cyclical queries like the following:

```js
query evil {
  album(id: 42) {
    songs {
      album {
        songs {
          album {
            songs {
              album {
                songs {
                  album {
                    songs {
                      album {
                        songs {
                          album {
                            # and so on...
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```