### PR TITLE
feat(tools): add visability of auth0 rules

### DIFF
--- a/auth0-rules/README.md
+++ b/auth0-rules/README.md
@@ -1,0 +1,5 @@
+## Auth0 Rules
+
+The functions held in this directory have no direct effect inside the open-api, but are held here for visability and code review.
+
+They are subject to a manual deploy process, that is to say, we copy/paste them inside the Auth0 dashboard.

--- a/auth0-rules/add-accountLinkId-to-token.js
+++ b/auth0-rules/add-accountLinkId-to-token.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+
+/*
+
+  Function name should be removed for deployment
+
+  uuid is global inside Auth0 Rules
+
+  https://auth0.com/docs/appliance/modules
+
+*/
+
+function addAccountLinkId(user, context, callback) {
+  const namespace = 'https://www.freecodecamp.org/accountLinkId';
+  user.app_metadata = user.app_metadata || {};
+  user.app_metadata.accountLinkId = user.app_metadata.accountLinkId || uuid();
+  context.idToken[namespace] = user.app_metadata.accountLinkId;
+
+  callback(null, user, context);
+}

--- a/auth0-rules/add-accountLinkId-to-token.js
+++ b/auth0-rules/add-accountLinkId-to-token.js
@@ -11,10 +11,11 @@
 */
 
 function addAccountLinkId(user, context, callback) {
-  const namespace = 'https://www.freecodecamp.org/accountLinkId';
+  const namespace = 'https://auth-ns.freecodecamp.org/';
   user.app_metadata = user.app_metadata || {};
   user.app_metadata.accountLinkId = user.app_metadata.accountLinkId || uuid();
-  context.idToken[namespace] = user.app_metadata.accountLinkId;
+  context.idToken[namespace + 'accountLinkId'] =
+    user.app_metadata.accountLinkId;
 
   callback(null, user, context);
 }

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -8,7 +8,7 @@ const { JWT_CERT } = process.env;
 
 export { updateAppMetaData } from './auth0';
 
-export const namespace = 'https://www.freecodecamp.org/';
+export const namespace = 'https://auth-ns.freecodecamp.org/';
 
 export const getTokenFromContext = ctx =>
   ctx &&

--- a/test/utils/test-environment.js
+++ b/test/utils/test-environment.js
@@ -3,7 +3,7 @@ const NodeEnvironment = require('jest-environment-node');
 
 // can be found in ~/src/auth/index.js
 // not 'required' due to jest no knowing how to read es6 modules
-const namespace = 'https://www.freecodecamp.org/';
+const namespace = 'https://auth-ns.freecodecamp.org/';
 
 const { JWT_CERT } = process.env;
 


### PR DESCRIPTION
In looking into the `accountLinkId` issue described in #107, I found it was as simple as adding `uuid()` inside the rule