### PR TITLE
fix: use secret variable to prevent spam from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/333b428d296e97d5385d
+      - ${GITTER_WEBHOOK}
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,7 @@ custom:
     includeModules: true
   notification:
     webhook:
-      url: https://webhooks.gitter.im/e/957145b550e13c6d3a80
+      url: ${env:GITTER_WEBHOOK}
 
 functions:
   graphql:


### PR DESCRIPTION
I have:
* removed the Gitter Travis integration
* deleted a non functioning webhook
* added a secret variable that is only available in our repo, working around a Travis limitation