### PR TITLE
fix: webhooks were broken until this commit, and no version was cut

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "serverless": "^1.26.1",
     "serverless-offline": "^3.20.0",
     "serverless-offline-scheduler": "^0.3.3",
+    "serverless-plugin-notification":
+      "https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763",
     "serverless-webpack": "^5.1.1",
     "snyk": "^1.73.0",
     "uuid": "^3.2.1",
@@ -88,7 +90,6 @@
     "nodemon": "^1.17.3",
     "prettier": "^1.11.1",
     "prettier-package-json": "^1.5.1",
-    "serverless-plugin-notification": "^1.3.0",
     "sinon": "^4.5.0",
     "sinon-stub-promise": "^4.0.0",
     "source-map-support": "^0.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6639,9 +6639,9 @@ serverless-offline@^3.20.0:
     uuid "^3.2.1"
     velocityjs "^0.9.3"
 
-serverless-plugin-notification@^1.3.0:
+"serverless-plugin-notification@https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763":
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/serverless-plugin-notification/-/serverless-plugin-notification-1.3.0.tgz#b64afff3618a0bb4251f0884eeeabb2e57e676bb"
+  resolved "https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763"
   dependencies:
     bluebird "^3.5.0"
     request-promise-lite "0.9"


### PR DESCRIPTION
A fix was committed, but no version was cut. I've raised https://github.com/maasglobal/serverless-plugin-notification/issues/4 but in the meanwhile we can use the commit directly.