### PR TITLE
fix: switch to forked package, to prevent yarn - npm conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "serverless": "^1.26.1",
     "serverless-offline": "^3.20.0",
     "serverless-offline-scheduler": "^0.3.3",
-    "serverless-plugin-notification":
-      "https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763",
     "serverless-webpack": "^5.1.1",
     "snyk": "^1.73.0",
     "uuid": "^3.2.1",
@@ -90,6 +88,7 @@
     "nodemon": "^1.17.3",
     "prettier": "^1.11.1",
     "prettier-package-json": "^1.5.1",
+    "serverless-plugin-notification-ojongerius": "^1.3.1",
     "sinon": "^4.5.0",
     "sinon-stub-promise": "^4.0.0",
     "source-map-support": "^0.5.4"

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,7 +24,7 @@ plugins:
   - serverless-webpack
   - serverless-offline-scheduler
   - serverless-offline
-  - serverless-plugin-notification
+  - serverless-plugin-notification-ojongerius
 
 custom:
   serverless-offline:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6639,9 +6639,9 @@ serverless-offline@^3.20.0:
     uuid "^3.2.1"
     velocityjs "^0.9.3"
 
-"serverless-plugin-notification@https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763":
-  version "1.3.0"
-  resolved "https://github.com/maasglobal/serverless-plugin-notification.git#15ff3b283c37bac0400a18ae127cc1eda9438763"
+serverless-plugin-notification-ojongerius@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-notification-ojongerius/-/serverless-plugin-notification-ojongerius-1.3.1.tgz#be718f4296500147cd3db9466fcb8faf8cde8c87"
   dependencies:
     bluebird "^3.5.0"
     request-promise-lite "0.9"


### PR DESCRIPTION
When running, `sls` will run `npm ls` which will fail if you install a package from a github repo with a specific commit, which I did as a workaround for a maintainer not cutting a new release. See https://travis-ci.org/freeCodeCamp/open-api/builds/374666260#L715

My workaround, while the maintainers of the upstream package take their time, was to fork the repo and push another package to npm. This is fugly but it seems to work.

This should workaround the workaround 🤪

@Bouncey @raisedadead any other ways I could have done this?