### PR TITLE
fix: test is https webhook endpoint works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
   webhooks:
     urls:
       - ${GITTER_WEBHOOK}
-      - http://0323326e.ngrok.io/post
+      - https://0323326e.ngrok.io/post
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
I've seen people having issues with https endpoints, and all examples use http instead of https.