### PR TITLE
fix: add empty value for gitter webhook url 

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,7 @@
+GITTER_WEBHOOK=''
 MONGODB_URL='mongodb://foo:bar@baz:41019/quuz'
 GRAPHQL_ENDPOINT_URL='/graphql'
-JWT_CERT="secret"
+JWT_CERT='secret'
 
 AUTH0_NAMESPACE='https://<tenant-name>.auth0.com'
 AUTH0_CLIENT_ID='its-me!'


### PR DESCRIPTION
This will suppress warnings when running locally.

Addresses #129 