### PR TITLE
fix: these are the stage / env names used by deploy scripts

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -43,8 +43,8 @@ custom:
         endpoint: ${env:GITTER_WEBHOOK}
   alerts:
     stages: # Optionally - select which stages to deploy alarms to
-      - production
-      - staging
+      - prod
+      - stage
     dashboards: true
     topics:
       ok:


### PR DESCRIPTION
Noticed a mismatch between stages used in deploy.sh and serverless.yml, causing alarms to not be created. See log line https://travis-ci.org/freeCodeCamp/open-api/builds/376609058#L697