### PR TITLE
fix: removing announcing to Gitter

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -39,8 +39,6 @@ custom:
   aws-notifications:
       - protocol: email
         endpoint: ${env:SERVERLESS_EMAIL_NOTIFICATIONS}
-      - protocol: https # Announce on Gitter
-        endpoint: ${env:GITTER_WEBHOOK}
   alerts:
     stages: # Optionally - select which stages to deploy alarms to
       - prod


### PR DESCRIPTION
 Background, you either have to confirm the sns subscription on the webhook, *or* have another  Lamda subscribe and push to Gitter. Too much hassle for too little gain for now. email / sms for critical will do and Datadog can integrate with whatever chat solution we'll use.