### PR TITLE
fix: don't mask useful error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "start":
       "cross-env DEBUG=fcc:* nodemon node_modules/serverless/bin/serverless offline start --skipCacheInvalidation --stage dev",
     "test": "cross-env JWT_CERT=test jest --runInBand  --verbose --silent",
-    "test-ci": "cross-env JWT_CERT=test jest --runInBand --verbose"
+    "test-ci": "cross-env JWT_CERT=test jest --runInBand --verbose",
+    "test-update-snapshot":
+      "cross-env JWT_CERT=test jest --runInBand --verbose --updateSnapshot"
   },
   "config": {
     "commitizen": {

--- a/src/utils/asyncErrorHandler.js
+++ b/src/utils/asyncErrorHandler.js
@@ -1,9 +1,5 @@
-export default function asyncErrorHandler(
-  promise,
-  message = 'Something went wrong, please check and try again'
-) {
+export default function asyncErrorHandler(promise) {
   return promise.catch(err => {
-    console.error(err);
-    throw new Error(message);
+    throw err;
   });
 }

--- a/test/integration/__snapshots__/userFlow.test.js.snap
+++ b/test/integration/__snapshots__/userFlow.test.js.snap
@@ -57,7 +57,7 @@ Object {
 
 exports[`getUser should return errors for a malformed query: malformed query error 1`] = `
 Array [
-  [GraphQLError: Something went wrong, please check and try again],
+  [GraphQLError: Expected a valid email, got "Ooops!"],
 ]
 `;
 
@@ -85,7 +85,7 @@ Array [
 
 exports[`getUser should return null if no user has been found: no user error 1`] = `
 Array [
-  [GraphQLError: Something went wrong, please check and try again],
+  [GraphQLError: No user found for nowhere@tobe.seen],
 ]
 `;
 


### PR DESCRIPTION
Addresses #127

A bit on the fence about this one: this makes the asyncErrorHandler essentially do nothing. It would allow us to easily plugin more smarts later.