### PR TITLE
style(tools): relax rules for commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,7 @@ const { types, scopes, allowCustomScopes } = require('./commitizen.config');
 
 const validTypes = types.map(type => type.value);
 const validScopes = scopes.map(scope => scope.name);
-const scopeValidationLevel = allowCustomScopes ? 1 : 2;
+const scopeValidationLevel = allowCustomScopes ? 0 : 2;
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
@@ -14,6 +14,9 @@ module.exports = {
     // Apply valid scopes and types
     'scope-enum': [scopeValidationLevel, 'always', validScopes],
     'type-enum': [2, 'always', validTypes],
+
+    // Disable subject-case rule
+    'subject-case': [0, 'always'],
 
     // Disable language rule
     lang: [0, 'always', 'eng']


### PR DESCRIPTION
Allow commit message to be consistent with code changed

ISSUES CLOSED: #54 


Set `subject-case` to 0 since we would like to allow any string in the subject
Set `scope-enum` to 0 to allow custom scope without warning
