### PR TITLE
chore: make tests in CI a little less verbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start":
       "cross-env DEBUG=fcc:* nodemon node_modules/serverless/bin/serverless offline start --skipCacheInvalidation --stage dev",
     "test": "cross-env JWT_CERT=test jest --runInBand  --verbose --silent",
-    "test-ci": "cross-env JWT_CERT=test jest --runInBand --verbose",
+    "test-ci": "cross-env JWT_CERT=test jest --runInBand --verbose --silent",
     "test-update-snapshot":
       "cross-env JWT_CERT=test jest --runInBand --verbose --updateSnapshot"
   },


### PR DESCRIPTION
Runs do look cleaner now that we thrown errors instead of logging errors but they add no real value. 

Let's silence them.

Before:

```bash
▶ yarn test-ci
yarn run v1.6.0
$ cross-env JWT_CERT=test jest --runInBand --verbose
 PASS  test/integration/userFlow.test.js
  createUser
    ✓ should return null and an auth error without a token (60ms)
    ✓ should return null and an auth error with an invalid token (3ms)
    ✓ should create a user by query (61ms)
    ✓ should raise an error without email in token (10ms)
    ✓ should not create duplicate accounts (10ms)
  getUser
    ✓ should return null and an auth error without a token (3ms)
    ✓ should return null and an auth error with an invalid token (3ms)
    ✓ should return a user after one has been created (8ms)
    ✓ should return null if no user has been found (3ms)
    ✓ should return errors for a query skipping a mandatory field (1ms)
    ✓ should return errors for a malformed query (3ms)

  console.log node_modules/graphql-tools/dist/schemaGenerator.js:514
    { Error: You must provide a valid email
        at createUser (/Users/ojongerius/repos/fcc-open-api/src/dataLayer/mongo/user.js:39:11)
        at Object.<anonymous> (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:683:22)
        at class_1.<anonymous> (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:781:42)
        at step (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:51:23)
        at Object.next (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:32:53)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:26:71
        at new Promise (<anonymous>)
        at Object.<anonymous>.__awaiter (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:22:12)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:781:13
        at isAuthenticatedOnQuery (/Users/ojongerius/repos/fcc-open-api/src/graphql/resolvers/directives.js:24:32)
        at field.resolve (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:780:18)
        at resolveFieldValueOrError (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:531:18)
        at resolveField (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:495:16)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:339:18
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql/jsutils/promiseReduce.js:25:10
        at Array.reduce (<anonymous>)
      originalMessage: 'You must provide a valid email',
      message: 'Error in resolver Mutation.createUser\nYou must provide a valid email' }

  console.log node_modules/graphql-tools/dist/schemaGenerator.js:514
    { Error: Account already in use
        at createUser (/Users/ojongerius/repos/fcc-open-api/src/dataLayer/mongo/user.js:60:11)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:188:7)
      originalMessage: 'Account already in use',
      message: 'Error in resolver Mutation.createUser\nAccount already in use' }

  console.log node_modules/graphql-tools/dist/schemaGenerator.js:514
    { Error: No user found for nowhere@tobe.seen
        at getUserPromise (/Users/ojongerius/repos/fcc-open-api/src/dataLayer/mongo/user.js:28:14)
        at <anonymous>
      originalMessage: 'No user found for nowhere@tobe.seen',
      message: 'Error in resolver Query.getUser\nNo user found for nowhere@tobe.seen' }

  console.log node_modules/graphql-tools/dist/schemaGenerator.js:514
    { TypeError: Expected a valid email, got "Ooops!"
        at getUserPromise (/Users/ojongerius/repos/fcc-open-api/src/dataLayer/mongo/user.js:20:9)
        at new Promise (<anonymous>)
        at getUser (/Users/ojongerius/repos/fcc-open-api/src/dataLayer/mongo/user.js:17:10)
        at Object.<anonymous> (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:683:22)
        at class_1.<anonymous> (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:781:42)
        at step (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:51:23)
        at Object.next (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:32:53)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:26:71
        at new Promise (<anonymous>)
        at Object.<anonymous>.__awaiter (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/dist/schemaGenerator.js:22:12)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:781:13
        at isAuthenticatedOnQuery (/Users/ojongerius/repos/fcc-open-api/src/graphql/resolvers/directives.js:24:32)
        at field.resolve (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql-tools/src/schemaGenerator.ts:780:18)
        at resolveFieldValueOrError (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:531:18)
        at resolveField (/Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:495:16)
        at /Users/ojongerius/repos/fcc-open-api/node_modules/graphql/execution/execute.js:364:18
      originalMessage: 'Expected a valid email, got "Ooops!"',
      message: 'Error in resolver Query.getUser\nExpected a valid email, got "Ooops!"' }

 PASS  src/graphql/resolvers/directives.test.js
  isAuthenticatedOnField
    ✓ should return null if authenication fails (3ms)
    ✓ should return the secretValue if authentication succeeds (1ms)
  isAuthenticatedOnQuery
    ✓ should throw an error is auth fails (1ms)
    ✓ should call next if auth succeeds
  "main": "handler.js",

 PASS  src/dataLayer/mongo/user-dataLayer.test.js
  createUser
    ✓ should return a User object (22ms)
    ✓ should throw if accountLinkId is already in db (4ms)
  getUser
    ✓ should return a User object fo a valid request (2ms)
    ✓ should throw for a user not found (1ms)
    ✓ should throw if the supplied email is not valid (3ms)
  deleteUser
    ✓ should delete an existing user (10ms)
    ✓ should return with an error for a non existing user (1ms)
    ✓ should refuse deletion of other users (1ms)

Test Suites: 3 passed, 3 total
Tests:       23 passed, 23 total
Snapshots:   22 passed, 22 total
Time:        1.859s, estimated 5s
Ran all test suites.
✨  Done in 3.48s.
```

After:

```bash
▶ yarn test-ci
yarn run v1.6.0
$ cross-env JWT_CERT=test jest --runInBand --verbose --silent
 PASS  test/integration/userFlow.test.js
  createUser
    ✓ should return null and an auth error without a token (61ms)
    ✓ should return null and an auth error with an invalid token (3ms)
    ✓ should create a user by query (68ms)
    ✓ should raise an error without email in token (3ms)
    ✓ should not create duplicate accounts (9ms)
  getUser
    ✓ should return null and an auth error without a token (3ms)
    ✓ should return null and an auth error with an invalid token (2ms)
    ✓ should return a user after one has been created (5ms)
    ✓ should return null if no user has been found (3ms)
    ✓ should return errors for a query skipping a mandatory field (1ms)
    ✓ should return errors for a malformed query (2ms)

 PASS  src/dataLayer/mongo/user-dataLayer.test.js
  createUser
    ✓ should return a User object (22ms)
    ✓ should throw if accountLinkId is already in db (3ms)
  getUser
    ✓ should return a User object fo a valid request (2ms)
    ✓ should throw for a user not found (2ms)
    ✓ should throw if the supplied email is not valid (2ms)
  deleteUser
    ✓ should delete an existing user (11ms)
    ✓ should return with an error for a non existing user (2ms)
    ✓ should refuse deletion of other users (1ms)

 PASS  src/graphql/resolvers/directives.test.js
  isAuthenticatedOnField
    ✓ should return null if authenication fails (4ms)
    ✓ should return the secretValue if authentication succeeds (1ms)
  isAuthenticatedOnQuery
    ✓ should throw an error is auth fails (1ms)
    ✓ should call next if auth succeeds (1ms)

Test Suites: 3 passed, 3 total
Tests:       23 passed, 23 total
Snapshots:   22 passed, 22 total
Time:        1.859s, estimated 2s
✨  Done in 3.51s.
```


