### PR TITLE
feat: add community events

### DIFF
--- a/src/dataLayer/model/communityEvent.js
+++ b/src/dataLayer/model/communityEvent.js
@@ -1,0 +1,53 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const communityEventSchema = new Schema({
+  externalId: {
+    type: 'string',
+    description: 'Unique ID to refers to events externally',
+    required: true
+  },
+  title: {
+    type: 'string',
+    required: true
+  },
+  description: {
+    type: 'string',
+    required: true
+  },
+  owner: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'User',
+    description: 'ID of owner of event',
+    required: true
+  },
+  // Many to many relationship, see
+  // http://mongoosejs.com/docs/populate.html
+  attendees: [
+    {
+      type: mongoose.Schema.ObjectId,
+      ref: 'User',
+      description: 'Attendee'
+    }
+  ],
+
+  date: {
+    type: 'date',
+    required: true
+  },
+  imageUrl: {
+    type: 'string'
+  },
+  isLocked: {
+    type: 'boolean',
+    description: 'Event is locked',
+    default: true
+  }
+});
+
+module.exports = mongoose.model(
+  'CommunityEvent',
+  communityEventSchema,
+  'communityEvent'
+);

--- a/src/dataLayer/model/user.js
+++ b/src/dataLayer/model/user.js
@@ -3,6 +3,10 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const userSchema = new Schema({
+  externalId: {
+    type: 'string',
+    description: 'A UUID that is communicated externally'
+  },
   accountLinkId: {
     type: 'string',
     description: 'A uuid used to link SSO and freeCodeCamp accounts together',
@@ -111,7 +115,16 @@ const userSchema = new Schema({
   theme: {
     type: 'string',
     default: 'default'
-  }
+  },
+  // Many to many relationship, see
+  // http://mongoosejs.com/docs/populate.html
+  events: [
+    {
+      type: mongoose.Schema.ObjectId,
+      ref: 'Event',
+      description: 'Event'
+    }
+  ]
 });
 
 module.exports = mongoose.model('User', userSchema, 'user');

--- a/src/dataLayer/mongo/__snapshots__/event-datalayer.test.js.snap
+++ b/src/dataLayer/mongo/__snapshots__/event-datalayer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createCommunityEvent should throw if an attendee does yet exist 1`] = `"Unable to find attendee: {\\"email\\":\\"yeahnah@example.com\\"}"`;
+
+exports[`createCommunityEvent should throw if an imageUrl is not a valid URL 1`] = `"Expected valid URL string, got \\"notaUrl\\""`;
+
+exports[`createCommunityEvent should throw if an isLocked is not a Boolean 1`] = `"Expected a Boolean value, got \\"notaBoolean\\""`;
+
+exports[`deleteCommunityEvent should return with an error for a non existing event 1`] = `[Error: Event not found]`;

--- a/src/dataLayer/mongo/communityEvent.js
+++ b/src/dataLayer/mongo/communityEvent.js
@@ -1,0 +1,311 @@
+import validator from 'validator';
+import CommunityEventModel from '../model/communityEvent.js';
+import UserModel from '../model/user.js';
+import debug from 'debug';
+import uuid from 'uuid/v4';
+import { isEmpty, isString } from 'lodash';
+
+import { asyncErrorHandler } from '../../utils';
+import { verifyWebToken } from '../../auth';
+import { isArray } from 'util';
+
+const log = debug('fcc:dataLayer:mongo:event');
+
+function resolveAttendees(attendees) {
+  return new Promise(async function resolveAttendeesPromise(resolve, reject) {
+    if (!isArray(attendees)) {
+      reject(new TypeError('Expected list of attendees'));
+      return null;
+    }
+
+    const resolvedAttendeesResult = [];
+    for (const attendeeUuid of attendees) {
+      const attendee = await UserModel.findOne(attendeeUuid, '_id');
+
+      if (attendee && !attendee.isEmpty) {
+        resolvedAttendeesResult.push(attendee._id);
+      } else {
+        reject(`Unable to find attendee: ${JSON.stringify(attendeeUuid)}`);
+        return null;
+      }
+    }
+
+    resolve(resolvedAttendeesResult);
+  });
+}
+
+async function resolveAndPopulateEvent(query) {
+  return CommunityEventModel.findOne(query)
+    .populate('owner', 'name email')
+    .populate('attendees', 'name email')
+    .exec();
+}
+
+function validateQuery(input) {
+  return (
+    ('externalId' in input &&
+      (isString(input.externalId) && validator.isUUID(input.externalId))) ||
+    ('title' in input && isString(input.title))
+  );
+}
+
+export async function getCommunityEvent(root, vars) {
+  return new Promise(async function getCommunityEventPromise(resolve, reject) {
+    if (!('externalId' in vars) && !('title' in vars)) {
+      reject(new TypeError('Expected an event ID or title'));
+      return null;
+    }
+
+    const query =
+      'externalId' in vars
+        ? { externalId: vars.externalId }
+        : {
+            title: vars.title
+          };
+
+    if (!validateQuery(query)) {
+      reject(new TypeError('Expected a valid externalId or title'));
+      return null;
+    }
+
+    log(`Query: ${JSON.stringify(query)}`);
+    const event = await resolveAndPopulateEvent(query);
+    if (isEmpty(event)) {
+      return resolve(null);
+    }
+
+    return resolve(event);
+  });
+}
+
+function resolveAndPopulateEvents(query) {
+  return CommunityEventModel.find(query)
+    .populate('owner', 'name email')
+    .populate('attendees', 'name email')
+    .exec();
+}
+
+export async function getCommunityEvents(root, vars) {
+  return new Promise(async function getCommunityEventsPromise(resolve, reject) {
+    if (!('externalId' in vars) && !('title' in vars)) {
+      reject(new TypeError('Expected an event ID or title'));
+      return null;
+    }
+
+    const query =
+      'externalId' in vars
+        ? { externalId: vars.externalId }
+        : {
+            title: vars.title
+          };
+
+    if (!validateQuery(query)) {
+      reject(new TypeError('Expected a valid externalId or title'));
+      return null;
+    }
+
+    log(`Query: ${JSON.stringify(query)}`);
+    const events = await asyncErrorHandler(resolveAndPopulateEvents(query));
+
+    if (isEmpty(events)) {
+      return resolve(null);
+    }
+
+    return resolve(events);
+  });
+}
+
+export async function validatedRequestor(context) {
+  return new Promise(async function validatedRequestorPromise(resolve, reject) {
+    const { decoded } = verifyWebToken(context);
+    const { email } = decoded;
+
+    if (!isString(email) || !validator.isEmail(email)) {
+      reject(new Error('You must provide a valid email'));
+      return null;
+    }
+
+    const user = await UserModel.findOne({ email: email }, '_id')
+      .exec()
+      .catch(err => {
+        if (err) {
+          log(`Error finding user: ${JSON.stringify(err)}`);
+          reject(new Error('Something went wrong querying database'));
+          return null;
+        }
+      });
+
+    if (user.isEmpty) {
+      log(
+        `Unable to resolve user making request for email: ${JSON.stringify(
+          email
+        )}`
+      );
+      reject(new Error('Cannot resolve user of requestor'));
+      return null;
+    }
+
+    return resolve(user);
+  });
+}
+
+function validateAttendees(attendees) {
+  return new Promise(async function validateAttendeesPromise(resolve, reject) {
+    for (const attendee of attendees) {
+      if ('externalId' in attendee && !validator.isUUID(attendee.externalId)) {
+        reject(
+          new Error(
+            `Expected a valid externalId, got ${JSON.stringify(
+              attendee.externalId
+            )}`
+          )
+        );
+        return null;
+      } else if ('email' in attendee && !validator.isEmail(attendee.email)) {
+        reject(
+          new Error(
+            `Expected a valid email address, got ${JSON.stringify(
+              attendee.email
+            )}`
+          )
+        );
+        return null;
+      }
+    }
+    resolve();
+  });
+}
+
+export async function createCommunityEvent(root, vars, ctx) {
+  return new Promise(async function createCommunityEventPromise(
+    resolve,
+    reject
+  ) {
+    const user = await validatedRequestor(ctx).catch(err => {
+      if (err) {
+        reject(err);
+        return null;
+      }
+    });
+
+    if (user === null) {
+      return null;
+    }
+
+    const newEvent = {
+      title: vars.title,
+      description: vars.description,
+      owner: user.id,
+      date: vars.date,
+      externalId: uuid()
+    };
+
+    if ('imageUrl' in vars) {
+      if (!isString(vars.imageUrl) || !validator.isURL(vars.imageUrl)) {
+        reject(
+          `Expected valid URL string, got ${JSON.stringify(vars.imageUrl)}`
+        );
+        return null;
+      }
+
+      newEvent.imageUrl = vars.imageUrl;
+    }
+
+    if ('isLocked' in vars) {
+      if (!isString(vars.isLocked) || !validator.isBoolean(vars.isLocked)) {
+        reject(
+          `Expected a Boolean value, got ${JSON.stringify(vars.isLocked)}`
+        );
+        return null;
+      }
+
+      newEvent.isLocked = vars.isLocked;
+    }
+
+    if ('attendees' in vars) {
+      await validateAttendees(vars.attendees).catch(err => reject(err));
+      newEvent.attendees = await resolveAttendees(vars.attendees).catch(err => {
+        reject(err);
+        return null;
+      });
+    }
+
+    // TODO: populate object with what is there, and validate against a schema
+    const event = new CommunityEventModel(newEvent);
+
+    return await event.save(err => {
+      if (err) {
+        reject(err);
+        return null;
+      }
+      /* Will have attendees populated at this point
+      Note that it interestingly this will *not* have an ID:    
+      {
+        "title":"another new event",
+        "description":"cool event IV",
+        "owner":"5ad1c7ace769e064e3a3487b",
+        "date":"Mon 28 May 2018 13:28:28",
+        "externalId":"2c959437-34a6-43f8-9718-b800b5a0dcea",
+        "attendees":["5ad1c7ace769e064e3a3487b"]
+      }
+
+      Hence well use our external ID:
+      */
+
+      return resolve(
+        resolveAndPopulateEvent({ externalId: newEvent.externalId })
+      );
+    });
+  });
+}
+
+// TODO: Implement an update function
+// export async function updateEvent(root, vars, ctx) {
+// }
+
+// Delete event, should only be allowed by creator and / or admin
+export async function deleteCommunityEvent(root, vars, ctx) {
+  const user = await validatedRequestor(ctx).catch(err => {
+    if (err) {
+      throw new Error(err);
+    }
+  });
+
+  if ('externalId' in vars) {
+    if (!isString(vars.externalId) || !validator.isUUID(vars.externalId)) {
+      throw new TypeError('Not a valid UUID');
+    }
+  }
+
+  await CommunityEventModel.findOne({
+    externalId: vars.externalId
+  })
+    .exec()
+    .then((event, err) => {
+      if (err) {
+        throw err;
+      }
+
+      if (isEmpty(event)) {
+        throw new Error('Event not found');
+      }
+
+      if (event.owner.externalId !== user.externalId) {
+        throw new Error('Only allowed to delete events you own');
+      }
+    });
+
+  return await CommunityEventModel.findOneAndRemove({
+    externalId: vars.externalId
+  }).then((event, err) => {
+    if (err) {
+      log(`Error find and removing document: ${JSON.stringify(err)}`);
+      throw new Error('Something went wrong querying database');
+    }
+
+    if (!event) {
+      throw new Error(`No event with externalId ${vars.externalId}`);
+    }
+    return event;
+  });
+}

--- a/src/dataLayer/mongo/event-datalayer.test.js
+++ b/src/dataLayer/mongo/event-datalayer.test.js
@@ -1,0 +1,449 @@
+/* global expect beforeAll afterAll */
+import {
+  createCommunityEvent,
+  getCommunityEvent,
+  getCommunityEvents,
+  deleteCommunityEvent
+} from './communityEvent';
+import { createUser } from './user';
+import CommunityEvent from '../model/communityEvent.js';
+import { isObject, isEmpty } from 'lodash';
+import mongoose from 'mongoose';
+import uuid from 'uuid/v4';
+import { isDate, isArray } from 'util';
+
+const validContextForBrian = global.mockedContextWithValidTokenForBrian;
+const validContextForDennis = global.mockedContextWithValidTokenForDennis;
+const validContextForKen = global.mockedContextWithValidTokenForKen;
+
+const event = {
+  title: 'epoch',
+  description: 'The start of POSIX time',
+  date: 'Thu 1 Jan 1970 00:00:00'
+};
+
+const eventValidAttendees = {
+  ...event,
+  attendees: [
+    { email: 'dennisritchie@example.com' },
+    { email: 'kenthompson@example.com' }
+  ]
+};
+
+const eventInValidAttendees = {
+  ...event,
+  attendees: [{ email: 'yeahnah@example.com' }]
+};
+
+beforeAll(async function beforeAllTests() {
+  await mongoose.connect(global.__MONGO_URI__);
+  // Create some users for our tests
+  await createUser({}, {}, validContextForBrian);
+  await createUser({}, {}, validContextForDennis);
+  await createUser({}, {}, validContextForKen);
+
+  // Create an event
+  await createCommunityEvent({}, eventValidAttendees, validContextForBrian);
+});
+
+afterAll(async function afterAllTests() {
+  await mongoose.connection.db.dropDatabase();
+  await mongoose.disconnect();
+});
+
+describe('createCommunityEvent', () => {
+  it('should return an Event object', done => {
+    expect.assertions(7);
+    createCommunityEvent({}, eventValidAttendees, validContextForBrian)
+      .then(result => {
+        const {
+          externalId,
+          title,
+          description,
+          owner,
+          date,
+          attendees
+        } = result;
+        // there is some weird Promise thing going on with `result`
+        // which screws with lodash.has()
+
+        // TODO: DRY this please
+        const hasKeys =
+          !isEmpty(externalId) &&
+          !isEmpty(title) &&
+          !isEmpty(description) &&
+          !isEmpty(owner) &&
+          isDate(date) &&
+          isArray(attendees);
+
+        const hasOwnerKeys = !isEmpty(owner.name) && !isEmpty(owner.email);
+        const hasAttendeeKeys =
+          !isEmpty(attendees[0].name) && !isEmpty(attendees[0].email);
+
+        expect(isObject(result)).toBe(true);
+        expect(isObject(result.owner)).toBe(true);
+        expect(isObject(result.attendees[0])).toBe(true);
+        expect(result.attendees).toHaveLength(2);
+        expect(hasKeys).toBe(true);
+        expect(hasOwnerKeys).toBe(true);
+        expect(hasAttendeeKeys).toBe(true);
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should throw if an attendee does yet exist', done => {
+    expect.assertions(2);
+    createCommunityEvent({}, eventInValidAttendees, validContextForBrian).catch(
+      err => {
+        expect(err).toMatchSnapshot();
+        expect(err).toContain('Unable to find attendee');
+        done();
+        return;
+      }
+    );
+  });
+
+  it('should throw if an imageUrl is not a valid URL', done => {
+    expect.assertions();
+    createCommunityEvent(
+      {},
+      {
+        ...event,
+        imageUrl: 'notaUrl'
+      },
+      validContextForBrian
+    ).catch(err => {
+      expect(err).toMatchSnapshot();
+      expect(err).toContain('Expected valid URL string');
+      done();
+      return;
+    });
+  });
+
+  it('should throw if an isLocked is not a Boolean', done => {
+    expect.assertions(2);
+    createCommunityEvent(
+      {},
+      {
+        ...event,
+        isLocked: 'notaBoolean'
+      },
+      validContextForBrian
+    ).catch(err => {
+      expect(err).toMatchSnapshot();
+      expect(err).toContain('Expected a Boolean value');
+      done();
+      return;
+    });
+  });
+});
+
+describe('getCommunityEvent', () => {
+  it('should return an Event object for a valid request', done => {
+    expect.assertions(7);
+    getCommunityEvent({}, { title: 'epoch' }, validContextForBrian)
+      .then(result => {
+        const {
+          externalId,
+          title,
+          description,
+          owner,
+          date,
+          attendees
+        } = result;
+        // there is some weird Promise thing going on with `result`
+        // which screws with lodash.has()
+        const hasKeys =
+          !isEmpty(externalId) &&
+          !isEmpty(title) &&
+          !isEmpty(description) &&
+          !isEmpty(owner) &&
+          isDate(date) &&
+          isArray(attendees);
+
+        const hasOwnerKeys = !isEmpty(owner.name) && !isEmpty(owner.email);
+        const hasAttendeeKeys =
+          !isEmpty(attendees[0].name) && !isEmpty(attendees[0].email);
+
+        expect(isObject(result)).toBe(true);
+        expect(isObject(owner)).toBe(true);
+        expect(isObject(attendees[0])).toBe(true);
+        expect(attendees).toHaveLength(2);
+        expect(hasKeys).toBe(true);
+        expect(hasOwnerKeys).toBe(true);
+        expect(hasAttendeeKeys).toBe(true);
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('title search non existing event should return null', done => {
+    expect.assertions(1);
+    getCommunityEvent({}, { title: 'Yeah nah' }, validContextForBrian).then(
+      data => {
+        expect(data).toBe(null);
+        done();
+      }
+    );
+  });
+
+  it('externalId search for non existing event should return null', done => {
+    expect.assertions(1);
+    getCommunityEvent({}, { externalId: uuid() }, validContextForBrian).then(
+      data => {
+        expect(data).toBe(null);
+        done();
+      }
+    );
+  });
+
+  // TODO: DRY please
+  it('should throw if the externalId is not valid', done => {
+    expect.assertions(8);
+    Promise.all([
+      getCommunityEvent({}, { externalId: 1 }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      ),
+      getCommunityEvent({}, { externalId: 'abc' }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      ),
+      getCommunityEvent(
+        {},
+        { externalId: ['yeah nah'] },
+        validContextForBrian
+      ).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvent({}, { externalId: false }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      )
+    ]).then(() => {
+      done();
+    });
+  });
+
+  it('should throw if the title is not valid', done => {
+    expect.assertions(6);
+    Promise.all([
+      getCommunityEvent({}, { title: 1 }, validContextForBrian).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvent(
+        {},
+        { title: ['yeah nah'] },
+        validContextForBrian
+      ).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvent({}, { title: false }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      )
+    ]).then(() => {
+      done();
+    });
+  });
+});
+
+describe('getCommunityEvents', () => {
+  it('should return multiple Event objects for a valid request', done => {
+    expect.assertions(8);
+    getCommunityEvents({}, { title: 'epoch' }, validContextForBrian)
+      .then(result => {
+        const {
+          externalId,
+          title,
+          description,
+          owner,
+          date,
+          attendees
+        } = result[0];
+
+        // there is some weird Promise thing going on with `result`
+        // which screws with lodash.has()
+        const hasKeys =
+          !isEmpty(externalId) &&
+          !isEmpty(title) &&
+          !isEmpty(description) &&
+          !isEmpty(owner) &&
+          isDate(date) &&
+          isArray(attendees);
+
+        const hasOwnerKeys = !isEmpty(owner.name) && !isEmpty(owner.email);
+        const hasAttendeeKeys =
+          !isEmpty(attendees[0].name) && !isEmpty(attendees[0].email);
+
+        // TODO: 2 depend on other tests to create events for us,
+        // this is a bit brittle..
+        expect(result).toHaveLength(3);
+        expect(isObject(result)).toBe(true);
+        expect(isObject(owner)).toBe(true);
+        expect(isObject(attendees[0])).toBe(true);
+        expect(attendees).toHaveLength(2);
+        expect(hasKeys).toBe(true);
+        expect(hasOwnerKeys).toBe(true);
+        expect(hasAttendeeKeys).toBe(true);
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('title search non existing event should return null', done => {
+    expect.assertions(1);
+    getCommunityEvents({}, { title: 'Yeah nah' }, validContextForBrian).then(
+      data => {
+        expect(data).toBe(null);
+        done();
+      }
+    );
+  });
+
+  it('externalId search for non existing event should return null', done => {
+    expect.assertions(1);
+    getCommunityEvents({}, { externalId: uuid() }, validContextForBrian).then(
+      data => {
+        expect(data).toBe(null);
+        done();
+      }
+    );
+  });
+
+  // TODO: DRY please
+  it('should throw if the externalId is not valid', done => {
+    expect.assertions(8);
+    Promise.all([
+      getCommunityEvents({}, { externalId: 1 }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      ),
+      getCommunityEvents({}, { externalId: 'abc' }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      ),
+      getCommunityEvents(
+        {},
+        { externalId: ['yeah nah'] },
+        validContextForBrian
+      ).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvents({}, { externalId: false }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      )
+    ]).then(() => {
+      done();
+    });
+  });
+
+  it('should throw if the title is not valid', done => {
+    expect.assertions(6);
+    Promise.all([
+      getCommunityEvents({}, { title: 1 }, validContextForBrian).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvents(
+        {},
+        { title: ['yeah nah'] },
+        validContextForBrian
+      ).catch(err => {
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.message).toContain('Expected a valid externalId or title');
+      }),
+      getCommunityEvents({}, { title: false }, validContextForBrian).catch(
+        err => {
+          expect(err).toBeInstanceOf(TypeError);
+          expect(err.message).toContain('Expected a valid externalId or title');
+        }
+      )
+    ]).then(() => {
+      done();
+    });
+  });
+});
+
+describe('deleteCommunityEvent', () => {
+  it('should delete an existing event', async done => {
+    const event = {
+      title: 'deleteCommunityEvent event',
+      description: 'A boring test event',
+      date: 'Thu 1 Jan 1970 00:00:00'
+    };
+
+    const createdEvent = await createCommunityEvent(
+      {},
+      event,
+      validContextForBrian
+    );
+    const deletedEvent = await deleteCommunityEvent(
+      {},
+      { externalId: createdEvent.externalId },
+      validContextForBrian
+    );
+
+    expect(createdEvent.externalId).toMatch(deletedEvent.externalId);
+
+    const foundEvent = await CommunityEvent.findOne({
+      externalId: deletedEvent.externalId
+    }).exec();
+    expect(foundEvent).toBe(null);
+    done();
+  });
+
+  it('should return with an error for a non existing event', async done => {
+    try {
+      await deleteCommunityEvent(
+        {},
+        { externalId: uuid() },
+        validContextForBrian
+      );
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain('Event not found');
+      expect(err).toMatchSnapshot();
+    }
+    done();
+  });
+
+  it('should refuse deletion of events owned by other users', async done => {
+    const e = await CommunityEvent.findOne({ title: 'epoch' }).exec();
+    try {
+      await deleteCommunityEvent(
+        {},
+        { externalId: e.externalId },
+        validContextForKen
+      );
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain('Only allowed to delete events you own');
+      expect(err).toMatchSnapshot();
+    }
+    done();
+  });
+});

--- a/src/graphql/resolvers/communityEvent.js
+++ b/src/graphql/resolvers/communityEvent.js
@@ -1,0 +1,17 @@
+import {
+  getCommunityEvent,
+  getCommunityEvents,
+  createCommunityEvent,
+  deleteCommunityEvent
+} from '../../dataLayer/mongo/communityEvent';
+
+export const communityEventResolvers = {
+  Query: {
+    getCommunityEvent,
+    getCommunityEvents
+  },
+  Mutation: {
+    createCommunityEvent,
+    deleteCommunityEvent
+  }
+};

--- a/src/graphql/resolvers/index.js
+++ b/src/graphql/resolvers/index.js
@@ -1,4 +1,8 @@
+import { mergeResolvers } from 'merge-graphql-schemas';
+
 import { userResolvers } from './user';
+import { communityEventResolvers } from './communityEvent';
 
 export { createDirectives } from './directives';
-export default userResolvers;
+
+export default mergeResolvers([userResolvers, communityEventResolvers]);

--- a/src/graphql/typeDefs/CommunityEvent/index.js
+++ b/src/graphql/typeDefs/CommunityEvent/index.js
@@ -1,0 +1,9 @@
+import CommunityEventType from './type';
+import Query from './query';
+import Mutation from './mutation';
+
+export default `
+  ${CommunityEventType}
+  ${Query}
+  ${Mutation}
+`;

--- a/src/graphql/typeDefs/CommunityEvent/input.js
+++ b/src/graphql/typeDefs/CommunityEvent/input.js
@@ -1,0 +1,7 @@
+// Users by their external id or email address
+export default `
+input UserInput {
+  externalId: String
+  email: String
+}
+`;

--- a/src/graphql/typeDefs/CommunityEvent/mutation.js
+++ b/src/graphql/typeDefs/CommunityEvent/mutation.js
@@ -1,0 +1,13 @@
+// TODO: date should be a custom type
+export default `
+type Mutation {
+  createCommunityEvent(title: String!
+              title: String!       
+              description: String!
+              attendees: [UserInput]
+              date: String!
+              imageUrl: String
+              isLocked: Boolean): CommunityEvent @isAuthenticatedOnQuery
+  deleteCommunityEvent(externalId: String!): CommunityEvent @isAuthenticatedOnQuery
+}
+`;

--- a/src/graphql/typeDefs/CommunityEvent/query.js
+++ b/src/graphql/typeDefs/CommunityEvent/query.js
@@ -1,0 +1,8 @@
+export default `
+type Query {
+  getCommunityEvent(externalId: String
+                    title: String): CommunityEvent,
+  getCommunityEvents(externalId: String
+                    title: String): [CommunityEvent]
+}
+`;

--- a/src/graphql/typeDefs/CommunityEvent/type.js
+++ b/src/graphql/typeDefs/CommunityEvent/type.js
@@ -1,0 +1,16 @@
+import InputTypes from './input';
+
+export default `
+type CommunityEvent {
+  externalId: String
+  title: String!
+  description: String!
+  owner: User!
+  attendees: [User]
+  date: String!
+  imageUrl: String
+}
+
+${InputTypes}
+
+`;

--- a/src/graphql/typeDefs/User/input.js
+++ b/src/graphql/typeDefs/User/input.js
@@ -1,7 +1,7 @@
 export default `
 input CompletedChallengeInput {
   completedDate: Int!,
-  id: String!,
+  externalId: String!,
   solution: String,
   githubLink: String
 }

--- a/src/graphql/typeDefs/User/query.js
+++ b/src/graphql/typeDefs/User/query.js
@@ -1,5 +1,7 @@
 export default `
 type Query {
-  getUser(email: String!): User @isAuthenticatedOnQuery
+  getUser(email: String
+          externalId: String
+  ): User @isAuthenticatedOnQuery
 }
 `;

--- a/src/graphql/typeDefs/User/type.js
+++ b/src/graphql/typeDefs/User/type.js
@@ -10,6 +10,7 @@ type CompletedChallenge {
 }
 
 type User {
+  externalId: String
   accountLinkId: String!
   email: String!
   isCheater: Boolean

--- a/src/graphql/typeDefs/index.js
+++ b/src/graphql/typeDefs/index.js
@@ -1,5 +1,6 @@
 import { mergeTypes } from 'merge-graphql-schemas';
 import User from './User';
+import CommunityEvent from './CommunityEvent';
 import directives from './directives';
 
-export default mergeTypes([User, directives]);
+export default mergeTypes([User, CommunityEvent, directives]);

--- a/test/integration/__snapshots__/eventFlow.test.js.snap
+++ b/test/integration/__snapshots__/eventFlow.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createEvent should create an event by query: new event 1`] = `
+Object {
+  "description": "The start of POSIX time",
+  "owner": Object {
+    "email": "briankernighan@example.com",
+    "externalId": null,
+  },
+  "title": "epoch",
+}
+`;
+
+exports[`createEvent should create an event by query: no errors 1`] = `undefined`;
+
+exports[`createEvent should raise an error without email in token: no email 1`] = `
+Array [
+  [GraphQLError: You must provide a valid email],
+]
+`;
+
+exports[`createEvent should raise an error without email in token: null 1`] = `null`;
+
+exports[`createEvent should return null and an auth error with an invalid token: no auth error 1`] = `
+Array [
+  [GraphQLError: You are not authorized, jwt malformed],
+]
+`;
+
+exports[`createEvent should return null and an auth error without a token: not logged in 1`] = `
+Array [
+  [GraphQLError: You must supply a JSON Web Token for authorization, are you logged in?],
+]
+`;
+
+exports[`getEvent should return an event after one has been created: event found 1`] = `
+Object {
+  "description": "The start of POSIX time",
+  "owner": Object {
+    "email": "briankernighan@example.com",
+  },
+  "title": "epoch",
+}
+`;
+
+exports[`getEvent should return an event after one has been created: no errors 1`] = `undefined`;
+
+exports[`getEvent should return errors for a malformed query: malformed query error 1`] = `
+Array [
+  [GraphQLError: Expected a valid externalId or title],
+]
+`;
+
+exports[`getEvent should return errors for a query skipping a mandatory field: skipped mandatory field error 1`] = `
+Array [
+  [GraphQLError: Expected an event ID or title],
+]
+`;
+
+exports[`getEvent should return null if no event has been found: no event error 1`] = `undefined`;
+
+exports[`getEvent should return null if no event has been found: null event 1`] = `null`;

--- a/test/integration/__snapshots__/userFlow.test.js.snap
+++ b/test/integration/__snapshots__/userFlow.test.js.snap
@@ -68,7 +68,7 @@ Array [
 
 exports[`getUser should return errors for a query skipping a mandatory field: skipped mandatory field error 1`] = `
 Array [
-  [GraphQLError: Field "getUser" argument "email" of type "String!" is required but not provided.],
+  [GraphQLError: Expected a valid email, got undefined],
 ]
 `;
 

--- a/test/integration/eventFlow.test.js
+++ b/test/integration/eventFlow.test.js
@@ -1,0 +1,233 @@
+/* global beforeAll afterAll expect */
+import mongoose from 'mongoose';
+import { graphql } from 'graphql';
+import { createUser } from '../../src/dataLayer/mongo/user';
+import { createCommunityEvent } from '../../src/dataLayer/mongo/communityEvent';
+import { graphqlSchema } from '../../src/handler';
+
+const contextNoToken = global.mockedContextWithOutToken;
+const invalidContext = global.mockedContextWithInValidToken;
+const validContextCharlie = global.mockedContextWithValidTokenForCharlie;
+const contextNoEmail = global.mockedContextWithNoEmailToken;
+const validContextForBrian = global.mockedContextWithValidTokenForBrian;
+const validContextForDennis = global.mockedContextWithValidTokenForDennis;
+
+const event = {
+  title: 'epoch',
+  description: 'The start of POSIX time',
+  date: 'Thu 1 Jan 1970 00:00:00'
+};
+
+beforeAll(async function beforeAllTests() {
+  await mongoose.connect(global.__MONGO_URI__);
+
+  // Create two test users
+  await createUser({}, {}, validContextForBrian);
+  await createUser({}, {}, validContextForDennis);
+
+  // Create a test event
+  await createCommunityEvent({}, event, validContextForBrian);
+});
+
+afterAll(async function afterAllTests() {
+  await mongoose.connection.db.dropDatabase();
+  await mongoose.disconnect();
+});
+
+// language=GraphQL
+
+const createCommunityEventQuery = `
+mutation createCommunityEvent {
+  createCommunityEvent(
+    title: "epoch"
+    description: "The start of POSIX time"
+    date: "Thu 1 Jan 1970 00:00:0"
+    attendees: [{email: "dennisritchie@example.com"}]
+  ) {
+    title
+    description
+    owner {
+      email
+      externalId
+    }
+  }
+}
+`;
+
+const expectedCommunityEventQuery = `
+    query {
+        getCommunityEvent(title: "epoch") {
+          title
+          description
+          owner {
+            email
+          }
+        }
+    }
+  `;
+
+const expectedNoCommunityEventQuery = `
+    query {
+      getCommunityEvent(title: "yeah nah") {
+        title
+        description
+        owner {
+          email
+        }
+      }
+    }
+  `;
+
+const skippedMandatoryFieldQuery = `
+  query {
+    getCommunityEvent {
+      title
+      description
+      owner {
+        email
+      }
+    }
+  }
+`;
+
+const malformedQuery = `
+    query {
+      getCommunityEvent(externalId: "yeah nah") {
+        title
+        description
+        owner {
+          email
+        }
+      }
+    }
+  `;
+
+const rootValue = {};
+
+describe('createEvent', () => {
+  it('should return null and an auth error without a token', done => {
+    expect.assertions(1);
+
+    graphql(graphqlSchema, createCommunityEventQuery, rootValue, contextNoToken)
+      .then(({ errors }) => {
+        expect(errors).toMatchSnapshot('not logged in');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should return null and an auth error with an invalid token', done => {
+    expect.assertions(1);
+
+    graphql(graphqlSchema, createCommunityEventQuery, rootValue, invalidContext)
+      .then(({ errors }) => {
+        expect(errors).toMatchSnapshot('no auth error');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should create an event by query', done => {
+    expect.assertions(2);
+
+    graphql(
+      graphqlSchema,
+      createCommunityEventQuery,
+      rootValue,
+      validContextForBrian
+    )
+      .then(({ data, errors }) => {
+        expect(data.createCommunityEvent).toMatchSnapshot('new event');
+        expect(errors).toMatchSnapshot('no errors');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should raise an error without email in token', done => {
+    expect.assertions(2);
+
+    graphql(graphqlSchema, createCommunityEventQuery, rootValue, contextNoEmail)
+      .then(({ data, errors }) => {
+        expect(data.createCommunityEvent).toMatchSnapshot('null');
+        expect(errors).toMatchSnapshot('no email');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+});
+
+describe('getEvent', () => {
+  it('should return an event after one has been created', done => {
+    expect.assertions(2);
+
+    graphql(
+      graphqlSchema,
+      expectedCommunityEventQuery,
+      rootValue,
+      validContextCharlie
+    )
+      .then(({ data, errors }) => {
+        expect(data.getCommunityEvent).toMatchSnapshot('event found');
+        expect(errors).toMatchSnapshot('no errors');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should return null if no event has been found', done => {
+    expect.assertions(2);
+
+    graphql(
+      graphqlSchema,
+      expectedNoCommunityEventQuery,
+      rootValue,
+      validContextCharlie
+    )
+      .then(result => {
+        const { data, errors } = result;
+        expect(data.getCommunityEvent).toMatchSnapshot('null event');
+        expect(errors).toMatchSnapshot('no event error');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should return errors for a query skipping a mandatory field', done => {
+    expect.assertions(1);
+
+    graphql(
+      graphqlSchema,
+      skippedMandatoryFieldQuery,
+      rootValue,
+      validContextCharlie
+    )
+      .then(result => {
+        const { errors } = result;
+        expect(errors).toMatchSnapshot('skipped mandatory field error');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should return errors for a malformed query', done => {
+    expect.assertions(2);
+
+    graphql(graphqlSchema, malformedQuery, rootValue, validContextCharlie)
+      .then(result => {
+        const { data, errors } = result;
+        expect(data.getCommunityEvent).toBe(null);
+        expect(errors).toMatchSnapshot('malformed query error');
+        return;
+      })
+      .then(done)
+      .catch(done);
+  });
+});

--- a/test/utils/test-environment.js
+++ b/test/utils/test-environment.js
@@ -20,6 +20,9 @@ class MongoEnvironment extends NodeEnvironment {
     this.global.idOfCharlie = '76b27a04-f537-4f7d-89a9-b469bf81208b';
     this.global.idOfLola = '85a937d5-c82c-4aa9-8e0b-9f2b9a7cc36c';
     this.global.idOfJane = '85a937d5-c82c-4aa9-89a9-b469bf81208b';
+    this.global.idOfBrian = 'd57c402c-647a-11e8-a678-14109fd1f8cb';
+    this.global.idOfDennis = 'e7189f2e-647a-11e8-9ed9-14109fd1f8cb';
+    this.global.idOfKen = 'e4a850da-647b-11e8-9fb2-14109fd1f8cb';
 
     const token = jwt.sign(
       {
@@ -52,6 +55,33 @@ class MongoEnvironment extends NodeEnvironment {
       },
       JWT_CERT
     );
+    const tokenForBrian = jwt.sign(
+      {
+        name: 'Brian Kernighan',
+        email: 'briankernighan@example.com',
+        [namespace + 'accountLinkId']: this.global.idOfBrian
+      },
+      JWT_CERT
+    );
+
+    const tokenForDennis = jwt.sign(
+      {
+        name: 'Dennis Ritchie',
+        email: 'dennisritchie@example.com',
+        [namespace + 'accountLinkId']: this.global.idOfDennis
+      },
+      JWT_CERT
+    );
+
+    const tokenForKen = jwt.sign(
+      {
+        name: 'Ken Thompson',
+        email: 'kenthompson@example.com',
+        [namespace + 'accountLinkId']: this.global.idOfKen
+      },
+      JWT_CERT
+    );
+
     const headers = {
       'Content-Type': 'application/json'
     };
@@ -96,6 +126,30 @@ class MongoEnvironment extends NodeEnvironment {
     };
     this.global.mockedContextWithInValidToken = {
       headers: headersWithInValidToken
+    };
+
+    const headersWithValidTokenForBrian = {
+      ...headers,
+      authorization: 'Bearer ' + tokenForBrian
+    };
+    this.global.mockedContextWithValidTokenForBrian = {
+      headers: headersWithValidTokenForBrian
+    };
+
+    const headersWithValidTokenForDennis = {
+      ...headers,
+      authorization: 'Bearer ' + tokenForDennis
+    };
+    this.global.mockedContextWithValidTokenForDennis = {
+      headers: headersWithValidTokenForDennis
+    };
+
+    const headersWithValidTokenForKen = {
+      ...headers,
+      authorization: 'Bearer ' + tokenForKen
+    };
+    this.global.mockedContextWithValidTokenForKen = {
+      headers: headersWithValidTokenForKen
     };
 
     await super.setup();


### PR DESCRIPTION
Not ready for QA but this adds visibility and facilitates discussion about the implementation.

I'll keep pagination (#90), dataloaders (#38)  and query depth limitation (#89) out of scope of this PR, but those things are exactly what I aim to work after Events go in. All of those things make sense when we have events in place, and will help mature the project.

* [x] Implement methods `src/dataLayer/mongo/communityEvent.js`
* [x] Agree on using an external uuid that is not coupled to any implementation
* [x] Write tests
* [x] Update integration test snapshot -`should return errors for a query skipping a mandatory field: skipped mandatory field error 1`