### PR TITLE
fix: updates to handle that we base64 encode certificates

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -2,7 +2,7 @@ SERVERLESS_EMAIL_NOTIFICATIONS=''
 GITTER_WEBHOOK=''
 MONGODB_URL='mongodb://foo:bar@baz:41019/quuz'
 GRAPHQL_ENDPOINT_URL='/graphql'
-JWT_CERT='secret'
+JWT_CERT='c2VjcmV0Cg='
 
 AUTH0_NAMESPACE='https://<tenant-name>.auth0.com'
 AUTH0_CLIENT_ID='its-me!'

--- a/scripts/generateHeader.js
+++ b/scripts/generateHeader.js
@@ -1,7 +1,8 @@
 const secrets = require('../src/config/secrets.js');
 const jwt = require('jsonwebtoken');
 
-const JWT_CERT = secrets.getSecret().JWT_CERT;
+const jwtEncoded = process.env.JWT_CERT;
+const JWT_CERT = Buffer.from(jwtEncoded, 'base64').toString('utf8');
 
 const token = jwt.sign(
   {


### PR DESCRIPTION
When making those changes in anger I was testing against learn, and did not verify locally generated headers still worked 🤦‍♂️

This fixes that 🎉 It's violates DRY, but it's so small I did not see the added value.