### PR TITLE
refactor(unit tests): DRY up the unit tests for invalid community events

### DIFF
--- a/src/dataLayer/mongo/event-datalayer.test.js
+++ b/src/dataLayer/mongo/event-datalayer.test.js
@@ -200,36 +200,30 @@ describe('getCommunityEvent', () => {
     );
   });
 
+  // function validateError(err) {
+  //   expect(err).toBeInstanceOf(TypeError);
+  //   expect(err.message).toContain('Expected a valid externalId or title');
+  // }
+
+  function getCommunityEventPromiseForTestCase(testCase) {
+    return getCommunityEvent(
+      {},
+      { externalId: testCase },
+      validContextForBrian
+    ).catch(err => {
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toContain('Expected a valid externalId or title');
+    });
+  }
+
   // TODO: DRY please
   it('should throw if the externalId is not valid', done => {
     expect.assertions(8);
     Promise.all([
-      getCommunityEvent({}, { externalId: 1 }, validContextForBrian).catch(
-        err => {
-          expect(err).toBeInstanceOf(TypeError);
-          expect(err.message).toContain('Expected a valid externalId or title');
-        }
-      ),
-      getCommunityEvent({}, { externalId: 'abc' }, validContextForBrian).catch(
-        err => {
-          expect(err).toBeInstanceOf(TypeError);
-          expect(err.message).toContain('Expected a valid externalId or title');
-        }
-      ),
-      getCommunityEvent(
-        {},
-        { externalId: ['yeah nah'] },
-        validContextForBrian
-      ).catch(err => {
-        expect(err).toBeInstanceOf(TypeError);
-        expect(err.message).toContain('Expected a valid externalId or title');
-      }),
-      getCommunityEvent({}, { externalId: false }, validContextForBrian).catch(
-        err => {
-          expect(err).toBeInstanceOf(TypeError);
-          expect(err.message).toContain('Expected a valid externalId or title');
-        }
-      )
+      getCommunityEventPromiseForTestCase(1),
+      getCommunityEventPromiseForTestCase('abc'),
+      getCommunityEventPromiseForTestCase(['yeah nah']),
+      getCommunityEventPromiseForTestCase(false)
     ]).then(() => {
       done();
     });


### PR DESCRIPTION
This is a fix for #188.  We're looking for feedback on this refactor to DRY up the unit tests.  Please let us know if we are going in the right direction.  Thank you. 