### PR TITLE
fix: Ping against node 8, builds started failing after LTS moved to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- lts/*
+- 8
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
First red build used lts v10.15.0 https://travis-ci.org/freeCodeCamp/open-api/builds/477182246
Last green build, used lts v8.12.0 https://travis-ci.org/freeCodeCamp/open-api/builds/444963919